### PR TITLE
fix(actions): Only allow read permission for linting workflow

### DIFF
--- a/.github/workflows/lint_and_check_formatting.yml
+++ b/.github/workflows/lint_and_check_formatting.yml
@@ -1,4 +1,6 @@
 name: Lint and check formatting
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/atdrago/adamdrago.com/security/code-scanning/1](https://github.com/atdrago/adamdrago.com/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (to check out code and install dependencies), set `contents: read` at the workflow level (top-level, after the `name` and before `on`). This will apply to all jobs in the workflow and ensure no unnecessary write permissions are granted. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
